### PR TITLE
Iris兼容的临时修复

### DIFF
--- a/src/main/java/cn/sh1rocu/slashblade/mixin/client/ItemInHandRendererMixin.java
+++ b/src/main/java/cn/sh1rocu/slashblade/mixin/client/ItemInHandRendererMixin.java
@@ -1,0 +1,58 @@
+package cn.sh1rocu.slashblade.mixin.client;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.AbstractClientPlayer;
+import net.minecraft.client.renderer.ItemInHandRenderer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.item.ItemStack;
+import mods.flammpfeil.slashblade.item.ItemSlashBlade;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(ItemInHandRenderer.class)
+public abstract class ItemInHandRendererMixin {
+    @Shadow
+    @Final
+    private Minecraft minecraft;
+
+    @ModifyVariable(
+            method = "renderArmWithItem(Lnet/minecraft/client/player/AbstractClientPlayer;FFLnet/minecraft/world/InteractionHand;FLnet/minecraft/world/item/ItemStack;FLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V",
+            at = @At("HEAD"),
+            index = 5,
+            argsOnly = true
+    )
+    private float sb$removeVanillaSwingForSlashBlade(float swingProgress, AbstractClientPlayer player,
+                                                     float partialTicks, float pitch, InteractionHand hand,
+                                                     float inSwingProgress, ItemStack stack) {
+        if (hand != InteractionHand.MAIN_HAND) {
+            return swingProgress;
+        }
+
+        if (!(stack.getItem() instanceof ItemSlashBlade)) {
+            return swingProgress;
+        }
+
+        if (this.minecraft == null || this.minecraft.player == null) {
+            return swingProgress;
+        }
+
+        if (player != this.minecraft.player) {
+            return swingProgress;
+        }
+
+        return 0.0F;
+    }
+}

--- a/src/main/java/mods/flammpfeil/slashblade/client/renderer/model/BladeFirstPersonRender.java
+++ b/src/main/java/mods/flammpfeil/slashblade/client/renderer/model/BladeFirstPersonRender.java
@@ -58,17 +58,21 @@ public class BladeFirstPersonRender {
             return;
 
         try (MSAutoCloser msac = MSAutoCloser.pushMatrix(matrixStack)) {
-            PoseStack.Pose me = matrixStack.last();
-            me.pose().identity();
-            me.normal().identity();
 
             float partialTicks = mc.getTimer().getGameTimeDeltaPartialTick(false);
 
-            matrixStack.mulPose(Axis.YP.rotationDegrees(180.0F - Mth.lerp(partialTicks, player.yRotO, player.getYRot())));
-
-            matrixStack.translate(0.0f, 0.0f, -0.5f);
+            matrixStack.translate(-0.12f, 1.0f, 0.5f);
             matrixStack.mulPose(Axis.ZP.rotationDegrees(180.0f));
             matrixStack.scale(1.2F, 1.0F, 1.0F);
+
+            // tilt slightly around Z(roll)
+            matrixStack.mulPose(Axis.ZP.rotationDegrees(-10.0f));
+
+            // rotate slightly outward around Y
+            matrixStack.mulPose(Axis.YP.rotationDegrees(0.9f));
+
+            // tilt slightly around X to lift blade (pitch)
+            matrixStack.mulPose(Axis.XP.rotationDegrees(-10.0F));
 
             // no sync pitch
             matrixStack.mulPose(Axis.XP.rotationDegrees(-Mth.clamp(player.getXRot(), -60F, 10F)));

--- a/src/main/resources/slashblade.fabric.mixins.json
+++ b/src/main/resources/slashblade.fabric.mixins.json
@@ -31,6 +31,7 @@
     "accessor.LivingEntityRendererAccessor",
     "client.ClientLevelMixin",
     "client.EntityRenderDispatcherMixin",
+    "client.ItemInHandRendererMixin",
     "client.ItemEntityRendererMixin",
     "client.LivingEntityRendererMixin",
     "client.MinecraftMixin",


### PR DESCRIPTION
删掉了原本的me.identity，直接将调整第一人称刀的手持渲染改为更稳定的局部变换链，保留自定义摆放，但不再继承原版不该叠加的手臂矩阵。

新增的mixin是为了可以屏蔽游戏本身自带的摆臂动画干扰来达到原本拔刀剑自定义动画的效果。但是不知为何没法成功拦截，导致移动的时候攻击偶尔会因为原版动画+拔刀剑动画重叠导致的刀身抖动现象。